### PR TITLE
Add news scraping WhatsApp agent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+seen_urls.txt

--- a/README.md
+++ b/README.md
@@ -1,0 +1,43 @@
+# IT Strategy Updates WhatsApp Agent
+
+This project contains a simple Python script that fetches recent
+articles from selected IT strategy consulting sources, summarizes them
+using a free open source language model, and sends the summaries to a
+WhatsApp number via Twilio.
+
+## Requirements
+
+- Python 3.8+
+- Packages listed in `requirements.txt`
+- A Twilio account with WhatsApp API access (for sending messages)
+
+## Installation
+
+```bash
+pip install -r requirements.txt
+```
+
+## Configuration
+
+Set the following environment variables before running the script:
+
+- `TWILIO_ACCOUNT_SID` – your Twilio Account SID
+- `TWILIO_AUTH_TOKEN` – your Twilio Auth Token
+- `TWILIO_WHATSAPP_FROM` – the WhatsApp-enabled Twilio number (e.g. `whatsapp:+14155238886`)
+- `WHATSAPP_TO` – your WhatsApp number (e.g. `whatsapp:+33600000000`)
+
+## Usage
+
+Run the agent manually:
+
+```bash
+python agent.py
+```
+
+To execute it daily, schedule it with `cron` or another job scheduler.
+
+## Notes
+
+The script stores processed article URLs in `seen_urls.txt` to avoid
+sending duplicate updates.
+

--- a/agent.py
+++ b/agent.py
@@ -1,0 +1,96 @@
+import os
+from pathlib import Path
+from typing import List, Dict
+
+import requests
+import feedparser
+from bs4 import BeautifulSoup
+from twilio.rest import Client
+from transformers import pipeline
+
+SEEN_FILE = Path("seen_urls.txt")
+
+# Example RSS feeds from IT strategy consulting firms or related sources
+SOURCES: List[Dict[str, str]] = [
+    {
+        "name": "Accenture Blog",
+        "rss": "https://www.accenture.com/us-en/blogs/blogs-index-rss"
+    },
+    {
+        "name": "McKinsey Insights",
+        "rss": "https://www.mckinsey.com/insights/rss"
+    },
+    {
+        "name": "BCG Publications",
+        "rss": "https://www.bcg.com/feeds/publications"
+    },
+]
+
+
+def load_seen() -> set:
+    if SEEN_FILE.exists():
+        return set(SEEN_FILE.read_text().splitlines())
+    return set()
+
+
+def save_seen(seen: set) -> None:
+    SEEN_FILE.write_text("\n".join(sorted(seen)))
+
+
+def fetch_article_content(url: str) -> str:
+    resp = requests.get(url, timeout=10)
+    resp.raise_for_status()
+    soup = BeautifulSoup(resp.text, "html.parser")
+    # Get text from paragraphs
+    paragraphs = [p.get_text(separator=" ", strip=True) for p in soup.find_all("p")]
+    return "\n".join(paragraphs)
+
+
+def summarize(text: str) -> str:
+    summarizer = pipeline("summarization")
+    # Hugging Face models typically limit input length; truncate long text
+    max_len = 1000
+    if len(text) > max_len:
+        text = text[:max_len]
+    summary = summarizer(text, max_length=130, min_length=30, do_sample=False)
+    return summary[0]["summary_text"]
+
+
+def send_whatsapp_message(body: str) -> None:
+    account_sid = os.environ["TWILIO_ACCOUNT_SID"]
+    auth_token = os.environ["TWILIO_AUTH_TOKEN"]
+    whatsapp_from = os.environ["TWILIO_WHATSAPP_FROM"]
+    whatsapp_to = os.environ["WHATSAPP_TO"]
+
+    client = Client(account_sid, auth_token)
+    client.messages.create(from_=whatsapp_from, body=body, to=whatsapp_to)
+
+
+def process_sources() -> None:
+    seen = load_seen()
+    new_seen = set(seen)
+
+    for source in SOURCES:
+        feed = feedparser.parse(source["rss"])
+        for entry in feed.entries:
+            url = entry.link
+            if url in seen:
+                continue
+            try:
+                content = fetch_article_content(url)
+                summary = summarize(content)
+                message = f"{source['name']}\n{entry.title}\n{summary}\n{url}"
+                send_whatsapp_message(message)
+                new_seen.add(url)
+            except Exception as exc:
+                print(f"Failed to process {url}: {exc}")
+
+    save_seen(new_seen)
+
+
+def main() -> None:
+    process_sources()
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+requests
+beautifulsoup4
+feedparser
+transformers
+torch
+Twilio


### PR DESCRIPTION
## Summary
- build simple Python script to scrape IT strategy consulting feeds
- summarize new articles with a free HuggingFace model
- send summaries via WhatsApp using Twilio
- document setup and usage in README
- add requirements and gitignore

## Testing
- `python -m py_compile agent.py`
